### PR TITLE
feat: convert response to discord embed

### DIFF
--- a/src/commands/hello.ts
+++ b/src/commands/hello.ts
@@ -1,5 +1,6 @@
 import { 
-    SlashCommandBuilder 
+    SlashCommandBuilder,
+    EmbedBuilder
 } from "discord.js";
 
 import { CoCommand } from "../structures";
@@ -9,7 +10,15 @@ const Hello = new CoCommand({
         .setName("hello")
         .setDescription("Replies with Hello!"),
     execute: async ({ interaction })=> {
-        await interaction.reply("Hello!");
+        const helloEmbed = new EmbedBuilder()
+            .setColor(0x0099FF)
+            .setTitle('Welcome to Code[Coogs]')
+            .setURL('https://www.codecoogs.com/')
+            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+            .setDescription('Hello!')
+            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+        interaction.reply({ embeds: [helloEmbed] });
     }
 });
 

--- a/src/commands/points.ts
+++ b/src/commands/points.ts
@@ -16,6 +16,30 @@ if (process.env.NODE_ENV === 'production') {
     dotenv.config({ path: '.env.development' });
 }
 
+const embedError = (description: string) => {
+    const errorEmbed = new EmbedBuilder()
+        .setColor('#ED4245')
+        .setTitle('Code[Coogs] Error')
+        .setURL('https://www.codecoogs.com/')
+        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+        .setDescription(description)
+        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+    return errorEmbed;
+}
+
+const embedSuccess = (title: string, description: string) => {
+    const successEmbed = new EmbedBuilder()
+        .setColor(0x0099FF)
+        .setTitle(title)
+        .setURL('https://www.codecoogs.com/')
+        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+        .setDescription(description)
+        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+    return successEmbed
+}
+
 const Points = new CoCommand({
     data: new SlashCommandBuilder()
         .setName("points")
@@ -37,13 +61,15 @@ const Points = new CoCommand({
             const mentionOptionChose = interaction.options.get("mention")
             const inputOptionChose = interaction.options.get("input")
             if (mentionOptionChose && inputOptionChose) {
-                await interaction.editReply("Only choose one option, either 'mention' or 'input'")
+                const embed = embedError("Only choose one option, either 'mention' or 'input'")
+                interaction.editReply({ embeds: [embed] });
                 return
             }
             else if (inputOptionChose) {
                 const inputField = interaction.options.get("input")?.value
                 if (inputField != 'lb') {
-                    await interaction.editReply("The only choices allowed in the input are: 'lb'")
+                    const embed = embedError("The only choices allowed in the input are: 'lb'")
+                    interaction.editReply({ embeds: [embed] });
                     return
                 }
                 const amount = 10;
@@ -60,42 +86,31 @@ const Points = new CoCommand({
                     })
                     .then(data => {
                         if (data.success) {
-                            const leaderboardEmbed = new EmbedBuilder()
-                                .setColor(0x0099FF)
-                                .setTitle('Code[Coogs] Points Leaderboard')
-                                .setURL('https://www.codecoogs.com/')
-                                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                                .setDescription('View the top 10 members with most points!')
-                                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+                            const embed = embedSuccess('Code[Coogs] Points Leaderboard', 'View the top 10 members with most points!')
                             data.data.forEach((entry: any, index: number) => {
                                 const rank = (index + 1).toString();
-                                leaderboardEmbed.addFields(
+                                embed.addFields(
                                     { name: `#${rank} - ${entry.first_name} ${entry.last_name}`, value: `${entry.points} points` }
                                 );
                             });
 
-                            interaction.editReply({ embeds: [leaderboardEmbed] });
+                            interaction.editReply({ embeds: [embed] });
                             return
                         }
-                        interaction.editReply("Error: " + data.error.message);
+                        const embed = embedError(data.error.message)
+                        interaction.editReply({ embeds: [embed] });
                     })
                     .catch(error => {
-                        interaction.editReply("Error: " + error);
+                        const embed = embedError(error)
+                        interaction.editReply({ embeds: [embed] });
                     })
             }
             else if (mentionOptionChose || (!inputOptionChose && !mentionOptionChose)) {
                 const roleName = interaction.options.get("mention")?.role?.name
                 const mentionedEveryoneOrHere = (roleName == "@everyone") || (roleName == "@here")
                 if (mentionedEveryoneOrHere) {
-                    const errorEmbed = new EmbedBuilder()
-                        .setColor('#ED4245')
-                        .setTitle('Code[Coogs] Error')
-                        .setURL('https://www.codecoogs.com/')
-                        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                        .setDescription("Don't mention @everyone or @here")
-                        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                    interaction.editReply({ embeds: [errorEmbed] });
+                    const embed = embedError("Don't mention @everyone or @here")
+                    interaction.editReply({ embeds: [embed] });
                     return
                 }
 
@@ -103,15 +118,8 @@ const Points = new CoCommand({
                 if (mentionedUser) {
                     const mentionedUserHasMemberRole = mentionedUser.roles.cache.some(role => role.name === 'member');
                     if (!mentionedUserHasMemberRole) {
-                        const errorEmbed = new EmbedBuilder()
-                            .setColor('#ED4245')
-                            .setTitle('Code[Coogs] Error')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription("The user you mentioned is not verified")
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                        interaction.editReply({ embeds: [errorEmbed] });
+                        const embed = embedError("The user you mentioned is not verified")
+                        interaction.editReply({ embeds: [embed] });
                         return 
                     }
                 }
@@ -119,15 +127,8 @@ const Points = new CoCommand({
                     const user = interaction.member as GuildMember;
                     const hasMemberRole = user.roles.cache.some(role => role.name === 'member');            
                     if (!hasMemberRole) {
-                        const errorEmbed = new EmbedBuilder()
-                            .setColor('#ED4245')
-                            .setTitle('Code[Coogs] Error')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription("You are not verified, use the '/verify' command to verify.")
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-    
-                        interaction.editReply({ embeds: [errorEmbed] });
+                        const embed = embedError("You are not verified, use the '/verify' command to verify.")
+                        interaction.editReply({ embeds: [embed] });
                         return 
                     }
                 }   
@@ -147,53 +148,25 @@ const Points = new CoCommand({
                     })
                     .then(data => {
                         if (data.success) {
-                            const pointsEmbed = new EmbedBuilder()
-                                .setColor(0x0099FF)
-                                .setTitle('Code[Coogs] User Points')
-                                .setURL('https://www.codecoogs.com/')
-                                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                                .setDescription('View a users points!')
-                                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                            pointsEmbed.addFields(
+                            const embed = embedSuccess('Code[Coogs] User Points', 'View a users points!')
+                            embed.addFields(
                                 { name: `${data.data.first_name} ${data.data.last_name}`, value: `${data.data.points} points` }
                             );
 
-                            interaction.editReply({ embeds: [pointsEmbed] });
+                            interaction.editReply({ embeds: [embed] });
                             return
                         }
-                        const errorEmbed = new EmbedBuilder()
-                            .setColor('#ED4245')
-                            .setTitle('Code[Coogs] Error')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription(`${data.error.message}`)
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                        interaction.editReply({ embeds: [errorEmbed] });
+                        const embed = embedError(data.error.message)
+                        interaction.editReply({ embeds: [embed] });
                     })
                     .catch(error => {
-                        const errorEmbed = new EmbedBuilder()
-                            .setColor('#ED4245')
-                            .setTitle('Code[Coogs] Error')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription(`${error}`)
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                        interaction.editReply({ embeds: [errorEmbed] });
+                        const embed = embedError(error)
+                        interaction.editReply({ embeds: [embed] });
                     })
             }
         } catch (error) {
-            const errorEmbed = new EmbedBuilder()
-                .setColor('#ED4245')
-                .setTitle('Code[Coogs] Error')
-                .setURL('https://www.codecoogs.com/')
-                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                .setDescription(`${error}`)
-                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-            interaction.editReply({ embeds: [errorEmbed] });
+            const embed = embedError(`${error}`)
+            interaction.editReply({ embeds: [embed] });
         }
     }
 });

--- a/src/commands/points.ts
+++ b/src/commands/points.ts
@@ -67,7 +67,6 @@ const Points = new CoCommand({
                                 .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
                                 .setDescription('View the top 10 members with most points!')
                                 .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-                                .setTimestamp()
                             data.data.forEach((entry: any, index: number) => {
                                 const rank = (index + 1).toString();
                                 leaderboardEmbed.addFields(
@@ -84,11 +83,19 @@ const Points = new CoCommand({
                         interaction.editReply("Error: " + error);
                     })
             }
-            else if (mentionOptionChose) {
+            else if (mentionOptionChose || (!inputOptionChose && !mentionOptionChose)) {
                 const roleName = interaction.options.get("mention")?.role?.name
                 const mentionedEveryoneOrHere = (roleName == "@everyone") || (roleName == "@here")
                 if (mentionedEveryoneOrHere) {
-                    await interaction.editReply("Don't do that!")
+                    const errorEmbed = new EmbedBuilder()
+                        .setColor('#ED4245')
+                        .setTitle('Code[Coogs] Error')
+                        .setURL('https://www.codecoogs.com/')
+                        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                        .setDescription("Don't mention @everyone or @here")
+                        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                    interaction.editReply({ embeds: [errorEmbed] });
                     return
                 }
 
@@ -96,7 +103,15 @@ const Points = new CoCommand({
                 if (mentionedUser) {
                     const mentionedUserHasMemberRole = mentionedUser.roles.cache.some(role => role.name === 'member');
                     if (!mentionedUserHasMemberRole) {
-                        await interaction.editReply("The user you mentioned is not verified.")
+                        const errorEmbed = new EmbedBuilder()
+                            .setColor('#ED4245')
+                            .setTitle('Code[Coogs] Error')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription("The user you mentioned is not verified")
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                        interaction.editReply({ embeds: [errorEmbed] });
                         return 
                     }
                 }
@@ -104,7 +119,15 @@ const Points = new CoCommand({
                     const user = interaction.member as GuildMember;
                     const hasMemberRole = user.roles.cache.some(role => role.name === 'member');            
                     if (!hasMemberRole) {
-                        await interaction.editReply("You are not verified, use the '/verify' command to verify.")
+                        const errorEmbed = new EmbedBuilder()
+                            .setColor('#ED4245')
+                            .setTitle('Code[Coogs] Error')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription("You are not verified, use the '/verify' command to verify.")
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+    
+                        interaction.editReply({ embeds: [errorEmbed] });
                         return 
                     }
                 }   
@@ -124,17 +147,53 @@ const Points = new CoCommand({
                     })
                     .then(data => {
                         if (data.success) {
-                            interaction.editReply(`${data.data.first_name} ${data.data.last_name}, you have ${data.data.points} points`);
+                            const pointsEmbed = new EmbedBuilder()
+                                .setColor(0x0099FF)
+                                .setTitle('Code[Coogs] User Points')
+                                .setURL('https://www.codecoogs.com/')
+                                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                                .setDescription('View a users points!')
+                                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                            pointsEmbed.addFields(
+                                { name: `${data.data.first_name} ${data.data.last_name}`, value: `${data.data.points} points` }
+                            );
+
+                            interaction.editReply({ embeds: [pointsEmbed] });
                             return
                         }
-                        interaction.editReply("Error: " + data.error.message);
+                        const errorEmbed = new EmbedBuilder()
+                            .setColor('#ED4245')
+                            .setTitle('Code[Coogs] Error')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription(`${data.error.message}`)
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                        interaction.editReply({ embeds: [errorEmbed] });
                     })
                     .catch(error => {
-                        interaction.editReply("Error: " + error);
+                        const errorEmbed = new EmbedBuilder()
+                            .setColor('#ED4245')
+                            .setTitle('Code[Coogs] Error')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription(`${error}`)
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                        interaction.editReply({ embeds: [errorEmbed] });
                     })
             }
         } catch (error) {
-            await interaction.editReply('Error: ' + error);
+            const errorEmbed = new EmbedBuilder()
+                .setColor('#ED4245')
+                .setTitle('Code[Coogs] Error')
+                .setURL('https://www.codecoogs.com/')
+                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                .setDescription(`${error}`)
+                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+            interaction.editReply({ embeds: [errorEmbed] });
         }
     }
 });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,12 +1,18 @@
-
 import { 
     SlashCommandBuilder,
     SlashCommandStringOption,
-    GuildMemberRoleManager
+    GuildMemberRoleManager,
+    EmbedBuilder
 } from "discord.js";
 const dotenv = require('dotenv');
 
 import { CoCommand } from "../structures";
+
+if (process.env.NODE_ENV === 'production') {
+    dotenv.config({ path: '.env.production' });
+} else {
+    dotenv.config({ path: '.env.development' });
+}
 
 const Verify = new CoCommand({
     data: new SlashCommandBuilder()
@@ -24,12 +30,6 @@ const Verify = new CoCommand({
 
             const userEmail = interaction.options.get("email")?.value;
             const userDiscordId = interaction.user.id
-        
-            if (process.env.NODE_ENV === 'production') {
-                dotenv.config({ path: '.env.production' });
-            } else {
-                dotenv.config({ path: '.env.development' });
-            }
             
             const url = process.env.VERIFY_DISCORD_API_ENDPOINT + `?email=${userEmail}&discordId=${userDiscordId}`
             const options = {
@@ -47,22 +47,63 @@ const Verify = new CoCommand({
                         const roleName = "member"
                         const memberRole = interaction.guild?.roles.cache.find(role => role.name === roleName);
                         if (!memberRole) {
-                            interaction.editReply("Role name '" + roleName + "' does not exist.");
+                            const errorEmbed = new EmbedBuilder()
+                                .setColor('#ED4245')
+                                .setTitle('Code[Coogs] Error')
+                                .setURL('https://www.codecoogs.com/')
+                                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                                .setDescription(`Role name '${roleName}' does not exist`)
+                                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                            interaction.editReply({ embeds: [errorEmbed] });
                             return
                         }
                         (interaction.member?.roles as GuildMemberRoleManager).add(memberRole);
 
-                        interaction.editReply("Successfully verified user!");
+                        const successEmbed = new EmbedBuilder()
+                            .setColor('#57F287')
+                            .setTitle('Code[Coogs] Success')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription("Successfully verified user!")
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                        interaction.editReply({ embeds: [successEmbed] });
+                        return
                     }
                     else {
-                        interaction.editReply("Error: " + data.error.message);
+                        const errorEmbed = new EmbedBuilder()
+                            .setColor('#ED4245')
+                            .setTitle('Code[Coogs] Error')
+                            .setURL('https://www.codecoogs.com/')
+                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                            .setDescription(data.error.message)
+                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                        interaction.editReply({ embeds: [errorEmbed] });
                     }
                 })
                 .catch(error => {
-                    interaction.editReply("Error: " + error);
+                    const errorEmbed = new EmbedBuilder()
+                        .setColor('#ED4245')
+                        .setTitle('Code[Coogs] Error')
+                        .setURL('https://www.codecoogs.com/')
+                        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                        .setDescription(error)
+                        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+                    interaction.editReply({ embeds: [errorEmbed] });
                 })
         } catch (error) {
-            await interaction.editReply('Error: ' + error);
+            const errorEmbed = new EmbedBuilder()
+                .setColor('#ED4245')
+                .setTitle('Code[Coogs] Error')
+                .setURL('https://www.codecoogs.com/')
+                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+                .setDescription(`${error}`)
+                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+            interaction.editReply({ embeds: [errorEmbed] });
         }
     }
 });

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -14,6 +14,30 @@ if (process.env.NODE_ENV === 'production') {
     dotenv.config({ path: '.env.development' });
 }
 
+const embedError = (description: string) => {
+    const errorEmbed = new EmbedBuilder()
+        .setColor('#ED4245')
+        .setTitle('Code[Coogs] Error')
+        .setURL('https://www.codecoogs.com/')
+        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+        .setDescription(description)
+        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+    return errorEmbed;
+}
+
+const embedSuccess = (description: string) => {
+    const successEmbed = new EmbedBuilder()
+        .setColor('#57F287')
+        .setTitle('Code[Coogs] Success')
+        .setURL('https://www.codecoogs.com/')
+        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
+        .setDescription(description)
+        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
+
+    return successEmbed
+}
+
 const Verify = new CoCommand({
     data: new SlashCommandBuilder()
         .setName("verify")
@@ -47,63 +71,28 @@ const Verify = new CoCommand({
                         const roleName = "member"
                         const memberRole = interaction.guild?.roles.cache.find(role => role.name === roleName);
                         if (!memberRole) {
-                            const errorEmbed = new EmbedBuilder()
-                                .setColor('#ED4245')
-                                .setTitle('Code[Coogs] Error')
-                                .setURL('https://www.codecoogs.com/')
-                                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                                .setDescription(`Role name '${roleName}' does not exist`)
-                                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                            interaction.editReply({ embeds: [errorEmbed] });
+                            const embed = embedError(`Role name '${roleName}' does not exist`)
+                            interaction.editReply({ embeds: [embed] });
                             return
                         }
                         (interaction.member?.roles as GuildMemberRoleManager).add(memberRole);
 
-                        const successEmbed = new EmbedBuilder()
-                            .setColor('#57F287')
-                            .setTitle('Code[Coogs] Success')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription("Successfully verified user!")
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                        interaction.editReply({ embeds: [successEmbed] });
+                        const embed = embedSuccess("Successfully verified user!")
+                        interaction.editReply({ embeds: [embed] });
                         return
                     }
                     else {
-                        const errorEmbed = new EmbedBuilder()
-                            .setColor('#ED4245')
-                            .setTitle('Code[Coogs] Error')
-                            .setURL('https://www.codecoogs.com/')
-                            .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                            .setDescription(data.error.message)
-                            .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                        interaction.editReply({ embeds: [errorEmbed] });
+                        const embed = embedSuccess(data.error.message)
+                        interaction.editReply({ embeds: [embed] });
                     }
                 })
                 .catch(error => {
-                    const errorEmbed = new EmbedBuilder()
-                        .setColor('#ED4245')
-                        .setTitle('Code[Coogs] Error')
-                        .setURL('https://www.codecoogs.com/')
-                        .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                        .setDescription(error)
-                        .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-                    interaction.editReply({ embeds: [errorEmbed] });
+                    const embed = embedSuccess(error)
+                    interaction.editReply({ embeds: [embed] });
                 })
         } catch (error) {
-            const errorEmbed = new EmbedBuilder()
-                .setColor('#ED4245')
-                .setTitle('Code[Coogs] Error')
-                .setURL('https://www.codecoogs.com/')
-                .setAuthor({ name: 'CoCo Bot', iconURL: 'https://www.codecoogs.com/assets/determined-coco.5399a2c0.webp', url: 'https://www.codecoogs.com/' })
-                .setDescription(`${error}`)
-                .setThumbnail('https://www.codecoogs.com/assets/computer-coco.60087ab0.webp')
-
-            interaction.editReply({ embeds: [errorEmbed] });
+            const embed = embedSuccess(`${error}`)
+            interaction.editReply({ embeds: [embed] });
         }
     }
 });


### PR DESCRIPTION
### Notes
- Update bot response to be discord embeds instead of simple text response

### Screenshots
<img width="390" alt="Screen Shot 2024-01-08 at 4 42 57 PM" src="https://github.com/codecoogs/bot/assets/91701930/33342a2b-c953-4417-8559-6b34f4f312a4">

<img width="491" alt="Screen Shot 2024-01-08 at 4 43 09 PM" src="https://github.com/codecoogs/bot/assets/91701930/83f05bf3-cc6a-4912-b620-f113433380a6">

<img width="378" alt="Screen Shot 2024-01-08 at 4 43 18 PM" src="https://github.com/codecoogs/bot/assets/91701930/8f723aa8-3f0d-4aea-9573-79c1d790d3ad">

![image](https://github.com/codecoogs/bot/assets/91701930/5492ef6d-24e0-4f62-a3d9-574233a3b527)

<img width="405" alt="Screen Shot 2024-01-08 at 4 43 34 PM" src="https://github.com/codecoogs/bot/assets/91701930/568b8483-fb5c-4fe9-9212-49dab5a87275">

<img width="414" alt="Screen Shot 2024-01-08 at 4 44 12 PM" src="https://github.com/codecoogs/bot/assets/91701930/fb65dd39-6b61-4790-b1c4-0d1c0e12e7b8">
