### PR TITLE
refactor: add subcommands to points

### DIFF
--- a/src/commands/points.ts
+++ b/src/commands/points.ts
@@ -55,17 +55,20 @@ const isMember = (user: GuildMember) => {
 
 const handleViewPoints = (interaction: ChatInputCommandInteraction) => {
     const mentionedUser = interaction.options.get("mention")?.member as GuildMember;
-    if (mentionedUser && !isMember(mentionedUser)) {
-        const embed = embedError("The user you mentioned is not verified.")
-        interaction.editReply({ embeds: [embed] });
-        return 
-    }
-
-    const user = interaction.member as GuildMember;
-    if (!isMember(user)) {
-        const embed = embedError("You are not verified, use the '/verify' command to verify.")
-        interaction.editReply({ embeds: [embed] });
-        return 
+    if (mentionedUser) {
+        if (!isMember(mentionedUser)) {
+            const embed = embedError("The user you mentioned is not verified.")
+            interaction.editReply({ embeds: [embed] });
+            return 
+        }
+    } 
+    else {
+        const user = interaction.member as GuildMember;
+        if (!isMember(user)) {
+            const embed = embedError("You are not verified, use the '/verify' command to verify.")
+            interaction.editReply({ embeds: [embed] });
+            return 
+        }
     }
 
     const discordId = mentionedUser ? mentionedUser.id : interaction.user.id;

--- a/src/commands/points.ts
+++ b/src/commands/points.ts
@@ -1,9 +1,8 @@
 
 import { 
     SlashCommandBuilder,
-    SlashCommandMentionableOption,
+    ChatInputCommandInteraction,
     GuildMember,
-    SlashCommandStringOption,
 } from "discord.js";
 import { CoCommand } from "../structures";
 import { embedSuccess, embedError } from "../constants/embeds";
@@ -20,131 +19,118 @@ const Points = new CoCommand({
     data: new SlashCommandBuilder()
         .setName("points")
         .setDescription("View member points!")
-        .addMentionableOption((option: SlashCommandMentionableOption) => 
-            option
-                .setName("mention")
-                .setDescription("Mention a discord user to view their member points!")
-                .setRequired(false))
-        .addStringOption((option: SlashCommandStringOption) => 
-            option
-                .setName("input")
-                .setDescription("View the points leaderboard by passing in 'lb' to the input!")
-                .setRequired(false)),
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("view")
+                .setDescription("View points of yourself or a mentioned user")
+                .addMentionableOption(option => 
+                    option.setName("mention")
+                        .setDescription("Mention a discord user")
+                        .setRequired(false)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("leaderboard")
+                .setDescription("View the points leaderboard")),
     execute: async ({ interaction })=> {
-        try {
-            await interaction.deferReply({ ephemeral: false });
+        await interaction.deferReply({ ephemeral: false });
 
-            const mentionOptionChose = interaction.options.get("mention")
-            const inputOptionChose = interaction.options.get("input")
-            if (mentionOptionChose && inputOptionChose) {
-                const embed = embedError("Only choose one option, either 'mention' or 'input'")
-                interaction.editReply({ embeds: [embed] });
-                return
-            }
-            else if (inputOptionChose) {
-                const inputField = interaction.options.get("input")?.value
-                if (inputField != 'lb') {
-                    const embed = embedError("The only choices allowed in the input are: 'lb'")
-                    interaction.editReply({ embeds: [embed] });
-                    return
-                }
-                const amount = 10;
-                const url = process.env.POINTS_LEADERBOARD_API_ENDPOINT + `?top=${amount}`
-                const options = {
-                    method: "GET",
-                    headers: {
-                        "Content-Type": "application/json"
-                    }
-                }
-                fetch(url, options)
-                    .then(res => {
-                        return res.json()
-                    })
-                    .then(data => {
-                        if (data.success) {
-                            const embed = embedSuccess('Code[Coogs] Points Leaderboard', 'View the top 10 members with most points!')
-                            data.data.forEach((entry: any, index: number) => {
-                                const rank = (index + 1).toString();
-                                embed.addFields(
-                                    { name: `#${rank} - ${entry.first_name} ${entry.last_name}`, value: `${entry.points} points` }
-                                );
-                            });
+        const subCommand = interaction.options.getSubcommand();
 
-                            interaction.editReply({ embeds: [embed] });
-                            return
-                        }
-                        const embed = embedError(data.error.message)
-                        interaction.editReply({ embeds: [embed] });
-                    })
-                    .catch(error => {
-                        const embed = embedError(error.toString())
-                        interaction.editReply({ embeds: [embed] });
-                    })
-            }
-            else if (mentionOptionChose || (!inputOptionChose && !mentionOptionChose)) {
-                const roleName = interaction.options.get("mention")?.role?.name
-                const mentionedEveryoneOrHere = (roleName == "@everyone") || (roleName == "@here")
-                if (mentionedEveryoneOrHere) {
-                    const embed = embedError("Don't mention @everyone or @here")
-                    interaction.editReply({ embeds: [embed] });
-                    return
-                }
-
-                const mentionedUser = interaction.options.get("mention")?.member as GuildMember;
-                if (mentionedUser) {
-                    const mentionedUserHasMemberRole = mentionedUser.roles.cache.some(role => role.name === 'member');
-                    if (!mentionedUserHasMemberRole) {
-                        const embed = embedError("The user you mentioned is not verified")
-                        interaction.editReply({ embeds: [embed] });
-                        return 
-                    }
-                }
-                else {
-                    const user = interaction.member as GuildMember;
-                    const hasMemberRole = user.roles.cache.some(role => role.name === 'member');            
-                    if (!hasMemberRole) {
-                        const embed = embedError("You are not verified, use the '/verify' command to verify.")
-                        interaction.editReply({ embeds: [embed] });
-                        return 
-                    }
-                }   
-
-                const discordId = mentionedUser ? mentionedUser.id : interaction.user.id;
-
-                const url = process.env.POINTS_API_ENDPOINT + `?discordId=${discordId}`
-                const options = {
-                    method: "GET",
-                    headers: {
-                        "Content-Type": "application/json"
-                    }
-                }
-                fetch(url, options)
-                    .then(res => {
-                        return res.json()
-                    })
-                    .then(data => {
-                        if (data.success) {
-                            const embed = embedSuccess('Code[Coogs] User Points', 'View a users points!')
-                            embed.addFields(
-                                { name: `${data.data.first_name} ${data.data.last_name}`, value: `${data.data.points} points` }
-                            );
-
-                            interaction.editReply({ embeds: [embed] });
-                            return
-                        }
-                        const embed = embedError(data.error.message)
-                        interaction.editReply({ embeds: [embed] });
-                    })
-                    .catch(error => {
-                        const embed = embedError(error.toString())
-                        interaction.editReply({ embeds: [embed] });
-                    })
-            }
-        } catch (error) {
-            const embed = embedError(`${error}`)
-            interaction.editReply({ embeds: [embed] });
+        switch(subCommand) {
+            case 'view':
+                handleViewPoints(interaction)
+                break;
+            case 'leaderboard':
+                handleLeaderboard(interaction);
+                break;
         }
     }
 });
 
 export default Points;
+
+const isMember = (user: GuildMember) => {
+    return user.roles.cache.some(role => role.name === 'member');             
+}
+
+const handleViewPoints = (interaction: ChatInputCommandInteraction) => {
+    const mentionedUser = interaction.options.get("mention")?.member as GuildMember;
+    if (mentionedUser && !isMember(mentionedUser)) {
+        const embed = embedError("The user you mentioned is not verified.")
+        interaction.editReply({ embeds: [embed] });
+        return 
+    }
+
+    const user = interaction.member as GuildMember;
+    if (!isMember(user)) {
+        const embed = embedError("You are not verified, use the '/verify' command to verify.")
+        interaction.editReply({ embeds: [embed] });
+        return 
+    }
+
+    const discordId = mentionedUser ? mentionedUser.id : interaction.user.id;
+
+    const url = process.env.POINTS_API_ENDPOINT + `?discordId=${discordId}`
+    const options = {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json"
+        }
+    }
+    fetch(url, options)
+        .then(res => {
+            return res.json()
+        })
+        .then(data => {
+            if (data.success) {
+                const embed = embedSuccess('Code[Coogs] User Points', 'View a users points!')
+                embed.addFields(
+                    { name: `${data.data.first_name} ${data.data.last_name}`, value: `${data.data.points} points` }
+                );
+
+                interaction.editReply({ embeds: [embed] });
+                return
+            }
+            const embed = embedError(data.error.message)
+            interaction.editReply({ embeds: [embed] });
+        })
+        .catch(error => {
+            const embed = embedError(error.toString())
+            interaction.editReply({ embeds: [embed] });
+        })
+}
+
+const handleLeaderboard = (interaction: ChatInputCommandInteraction) => {
+    const amount = 10;
+    const url = process.env.POINTS_LEADERBOARD_API_ENDPOINT + `?top=${amount}`
+    const options = {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json"
+        }
+    }
+    fetch(url, options)
+        .then(res => {
+            return res.json()
+        })
+        .then(data => {
+            if (data.success) {
+                const embed = embedSuccess('Code[Coogs] Points Leaderboard', 'View the top 10 members with most points!')
+                data.data.forEach((entry: any, index: number) => {
+                    const rank = (index + 1).toString();
+                    embed.addFields(
+                        { name: `#${rank} - ${entry.first_name} ${entry.last_name}`, value: `${entry.points} points` }
+                    );
+                });
+
+                interaction.editReply({ embeds: [embed] });
+                return
+            }
+            const embed = embedError(data.error.message)
+            interaction.editReply({ embeds: [embed] });
+        })
+        .catch(error => {
+            const embed = embedError(error.toString())
+            interaction.editReply({ embeds: [embed] });
+        })
+}


### PR DESCRIPTION
### Notes
- Made use of [subcommands](https://discordjs.guide/slash-commands/advanced-creation.html#subcommand) instead of using `input: lb`
   - We now have `/points view` with a mentionable option and `/points leaderboard` with no options 
- Extracted logic for each command in separate functions

### Screenshots
<img width="1137" alt="Screen Shot 2024-02-03 at 8 38 48 PM" src="https://github.com/codecoogs/bot/assets/91701930/eff6b581-cdd2-4242-abff-3df0b08d0553">
