### PR TITLE
feat: add assigned user next to todo fix #11

### DIFF
--- a/src/commands/todos.ts
+++ b/src/commands/todos.ts
@@ -7,7 +7,13 @@ type Todo = {
     id: number,
     title: string,
     deadline: string,
-    completed: boolean
+    completed: boolean,
+    todos_users: TodoUser,
+}
+
+type TodoUser = {
+    todos_id: number,
+    discord_id: string,
 }
 
 const Todos = new CoCommand({
@@ -146,7 +152,7 @@ const handleAllTodos = async (interaction: ChatInputCommandInteraction) => {
             const embed = embedSuccess("Code[Coogs] Todos", "Here are all todos, sorted by deadline");
             data.data.forEach((entry: Todo, index: number) => {
                 embed.addFields(
-                    { name: `${entry.id.toString()} - ${entry.title} - Due ${entry.deadline}`, value: `${entry.completed ? '✅ COMPLETE' : '🚧 INCOMPLETE'}` },
+                    { name: `${entry.id.toString()} - ${entry.title}`, value: `Assigned to <@${entry.todos_users.discord_id}> \nDue __${entry.deadline}__ \n${entry.completed ? '✅ COMPLETE' : '🚧 INCOMPLETE'}` },
                 );
             });
             interaction.editReply({ embeds: [embed] });


### PR DESCRIPTION
### Notes
- Add assigned user next to todo when running `/todos all` command
- Format embed better

### Screenshots
<img width="483" alt="Screen Shot 2024-02-05 at 6 55 47 PM" src="https://github.com/codecoogs/bot/assets/91701930/5bf4df38-ff9f-4a50-ac0a-46234d31ea81">
